### PR TITLE
Add bower.json file to enable the use of MediumButton with Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "MediumButton",
+  "version": "1.0.0",
+  "homepage": "https://github.com/arcs-/MediumButton",
+  "authors": [
+    "Patrick Stillhart <patrick@stillhart.biz>"
+  ],
+  "description": "MediumButton extends your Medium Editor with the possibility to add more buttons.",
+  "main": "src/MediumButton.js",
+  "moduleType": [],
+  "keywords": [
+    "medium",
+    "editor",
+    "medium editor"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
This little bower.json file allow you to correctly register your medium editor plugin on bower.io.
Bower is a fantastic dependency manager.
If you accept the pull, you only have to tag your changes in SEMVER (1.0.0 instead of 1.0) and everything will be ok.
Then, everybody will be able to use your plugin by downloading it through bower.

Don't hesitate if you have questions. Thanx for the plugin. 
